### PR TITLE
Add more rust & wasm tooling

### DIFF
--- a/docker/psibase-contributor.Dockerfile
+++ b/docker/psibase-contributor.Dockerfile
@@ -85,7 +85,10 @@ RUN mkdir -p ${PSINODE_PATH}    \
 # Copy in tool config
 COPY --from=ghcr.io/gofractally/https-tool-config / /
 
-
+# Install cargo edit
+# It's a helper tool that makes it easier to push updates for rust crates
+RUN $CARGO_HOME/bin/cargo install \
+    cargo-edit
 
 # Expose ports
 ## Psinode

--- a/docker/psibase-contributor.Dockerfile
+++ b/docker/psibase-contributor.Dockerfile
@@ -85,10 +85,10 @@ RUN mkdir -p ${PSINODE_PATH}    \
 # Copy in tool config
 COPY --from=ghcr.io/gofractally/https-tool-config / /
 
-# Install cargo edit
-# It's a helper tool that makes it easier to push updates for rust crates
+# Install nice-to-have rust/wasm tooling
 RUN $CARGO_HOME/bin/cargo install \
-    cargo-edit
+    cargo-edit \
+    wasm-tools
 
 # Expose ports
 ## Psinode

--- a/docker/ubuntu-2004-builder.Dockerfile
+++ b/docker/ubuntu-2004-builder.Dockerfile
@@ -123,6 +123,7 @@ RUN cd /root \
     && ./rustup.sh -y --no-modify-path \
     && /opt/cargo/bin/rustup target add wasm32-wasi \
     && /opt/cargo/bin/cargo install \
+        cargo-component     \
         mdbook              \
         mdbook-linkcheck    \
         mdbook-mermaid      \

--- a/docker/ubuntu-2204-builder.Dockerfile
+++ b/docker/ubuntu-2204-builder.Dockerfile
@@ -81,6 +81,7 @@ RUN cd /root \
     && ./rustup.sh -y --no-modify-path \
     && /opt/cargo/bin/rustup target add wasm32-wasi \
     && /opt/cargo/bin/cargo install \
+        cargo-component     \
         mdbook              \
         mdbook-linkcheck    \
         mdbook-mermaid      \


### PR DESCRIPTION
* cargo-component for building components, will be needed for building plugins as part of the psibase build process.
* cargo-edit makes version management easier
* wasm-tools allows disassembly and other functionality when working with wasm