### PR TITLE
add wasm32-unknown-unknown target to rust

### DIFF
--- a/docker/ubuntu-2004-builder.Dockerfile
+++ b/docker/ubuntu-2004-builder.Dockerfile
@@ -121,7 +121,9 @@ RUN cd /root \
     && curl --proto '=https' --tlsv1.2 -sSf -o rustup.sh https://sh.rustup.rs \
     && chmod 700 rustup.sh \
     && ./rustup.sh -y --no-modify-path \
-    && /opt/cargo/bin/rustup target add wasm32-wasi \
+    && /opt/cargo/bin/rustup target add \
+        wasm32-unknown-unknown  \
+        wasm32-wasi             \
     && /opt/cargo/bin/cargo install \
         cargo-component     \
         mdbook              \

--- a/docker/ubuntu-2204-builder.Dockerfile
+++ b/docker/ubuntu-2204-builder.Dockerfile
@@ -79,7 +79,9 @@ RUN cd /root \
     && curl --proto '=https' --tlsv1.2 -sSf -o rustup.sh https://sh.rustup.rs \
     && chmod 700 rustup.sh \
     && ./rustup.sh -y --no-modify-path \
-    && /opt/cargo/bin/rustup target add wasm32-wasi \
+    && /opt/cargo/bin/rustup target add \
+        wasm32-unknown-unknown  \
+        wasm32-wasi             \
     && /opt/cargo/bin/cargo install \
         cargo-component     \
         mdbook              \


### PR DESCRIPTION
wasm32-unknown-unknown used for building wasms that target a browser environment without the need for wasi interfaces.