### PR TITLE
switch to new arm runner

### DIFF
--- a/.github/workflows/builder-ubuntu.yml
+++ b/.github/workflows/builder-ubuntu.yml
@@ -18,12 +18,12 @@ jobs:
     name: psibase-builder-ubuntu-${{ inputs.ubuntu_version }}
     strategy:
       matrix:
-        runner: [ubuntu-latest, arm-runner-1]
+        runner: [ubuntu-latest, arm-runner-2]
         include:
           - runner: ubuntu-latest
             platform: "linux/amd64"
             platform_short: "amd64"
-          - runner: arm-runner-1
+          - runner: arm-runner-2
             platform: "linux/arm64"
             platform_short: "arm64"
     runs-on: ${{ matrix.runner }}
@@ -43,31 +43,6 @@ jobs:
 
       - name: Building ${{ matrix.platform_short }}
         run: true
-
-      # Docker install step can be removed after arm runners are out of beta
-      - name: Install docker
-        if: matrix.runner == 'arm-runner-1'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -yq ca-certificates curl
-          sudo install -m 0755 -d /etc/apt/keyrings
-          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-          sudo chmod a+r /etc/apt/keyrings/docker.asc
-          
-          # Add the repository to Apt sources:
-          echo \
-            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update
-
-          # Install
-          sudo apt-get install -yq docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-
-          # Give current user permission to run docker without sudo
-          sudo usermod -aG docker $USER
-          sudo apt-get install -yq acl
-          sudo setfacl --modify user:$USER:rw /var/run/docker.sock
 
       - name: Config docker buildx network
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -15,12 +15,12 @@ jobs:
     name: psinode-cli-builder
     strategy:
       matrix:
-        runner: [ubuntu-latest, arm-runner-1]
+        runner: [ubuntu-latest, arm-runner-2]
         include:
           - runner: ubuntu-latest
             platform: "linux/amd64"
             platform_short: "amd64"
-          - runner: arm-runner-1
+          - runner: arm-runner-2
             platform: "linux/arm64"
             platform_short: "arm64"
     runs-on: ${{ matrix.runner }}
@@ -33,31 +33,6 @@ jobs:
 
       - name: Building psinode-${{ matrix.platform_short }}
         run: true
-
-      # Docker install step can be removed after arm runners are out of beta
-      - name: Install docker
-        if: matrix.runner == 'arm-runner-1'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -yq ca-certificates curl
-          sudo install -m 0755 -d /etc/apt/keyrings
-          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-          sudo chmod a+r /etc/apt/keyrings/docker.asc
-          
-          # Add the repository to Apt sources:
-          echo \
-            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update
-
-          # Install
-          sudo apt-get install -yq docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-
-          # Give current user permission to run docker without sudo
-          sudo usermod -aG docker $USER
-          sudo apt-get install -yq acl
-          sudo setfacl --modify user:$USER:rw /var/run/docker.sock
 
       - name: Docker Buildx setup
         uses: docker/setup-buildx-action@v3
@@ -119,12 +94,12 @@ jobs:
     needs: psinode-cli-merger
     strategy:
       matrix:
-        runner: [ubuntu-latest, arm-runner-1]
+        runner: [ubuntu-latest, arm-runner-2]
         include:
           - runner: ubuntu-latest
             platform: "linux/amd64"
             platform_short: "amd64"
-          - runner: arm-runner-1
+          - runner: arm-runner-2
             platform: "linux/arm64"
             platform_short: "arm64"
     runs-on: ${{ matrix.runner }}
@@ -137,31 +112,6 @@ jobs:
 
       - name: Building psibase-${{ matrix.platform_short }}
         run: true
-
-      # Docker install step can be removed after arm runners are out of beta
-      - name: Install docker
-        if: matrix.runner == 'arm-runner-1'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -yq ca-certificates curl
-          sudo install -m 0755 -d /etc/apt/keyrings
-          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-          sudo chmod a+r /etc/apt/keyrings/docker.asc
-          
-          # Add the repository to Apt sources:
-          echo \
-            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update
-
-          # Install
-          sudo apt-get install -yq docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-
-          # Give current user permission to run docker without sudo
-          sudo usermod -aG docker $USER
-          sudo apt-get install -yq acl
-          sudo setfacl --modify user:$USER:rw /var/run/docker.sock
 
       - name: Docker Buildx setup
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/contributor.yml
+++ b/.github/workflows/contributor.yml
@@ -42,31 +42,6 @@ jobs:
       - name: Building ${{ matrix.platform_short }}
         run: true
 
-      # Docker install step can be removed after arm runners are out of beta
-      - name: Install docker
-        if: matrix.runner == 'arm-runner-1'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -yq ca-certificates curl
-          sudo install -m 0755 -d /etc/apt/keyrings
-          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-          sudo chmod a+r /etc/apt/keyrings/docker.asc
-          
-          # Add the repository to Apt sources:
-          echo \
-            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update
-
-          # Install
-          sudo apt-get install -yq docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-
-          # Give current user permission to run docker without sudo
-          sudo usermod -aG docker $USER
-          sudo apt-get install -yq acl
-          sudo setfacl --modify user:$USER:rw /var/run/docker.sock
-
       - name: Config docker buildx
         if: ${{ github.event_name != 'pull_request' }}
         uses: docker/setup-buildx-action@v3
@@ -182,7 +157,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner: arm-runner-1
+          - runner: arm-runner-2
             platform: "linux/arm64"
             platform_short: "arm64"
     runs-on: ${{ matrix.runner }}
@@ -195,31 +170,6 @@ jobs:
 
       - name: Building ${{ matrix.platform_short }}
         run: true
-
-      # Docker install step can be removed after arm runners are out of beta
-      - name: Install docker
-        if: matrix.runner == 'arm-runner-1'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -yq ca-certificates curl
-          sudo install -m 0755 -d /etc/apt/keyrings
-          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-          sudo chmod a+r /etc/apt/keyrings/docker.asc
-          
-          # Add the repository to Apt sources:
-          echo \
-            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update
-
-          # Install
-          sudo apt-get install -yq docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-
-          # Give current user permission to run docker without sudo
-          sudo usermod -aG docker $USER
-          sudo apt-get install -yq acl
-          sudo setfacl --modify user:$USER:rw /var/run/docker.sock
 
       - name: Config docker buildx
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/contributor.yml
+++ b/.github/workflows/contributor.yml
@@ -26,6 +26,9 @@ jobs:
           - runner: ubuntu-latest
             platform: "linux/amd64"
             platform_short: "amd64"
+          - runner: arm-runner-2
+            platform: "linux/arm64"
+            platform_short: "arm64"
     runs-on: ${{ matrix.runner }}
     services:
       registry:
@@ -146,91 +149,12 @@ jobs:
           name: psibase_contributor-${{ matrix.platform_short }}
           path: psibase_contributor-${{ matrix.platform_short }}.tar
           retention-days: 1
-  
-  # Arm64 runners don't have docker installed, so can't use the registry service to load
-  #  local images. Therefore, for now we must skip PR builds of psibase-contributor on arm.
-  #  Once arm-runners are out of beta, the runners will have docker installed on them by default,
-  #  and this special job can be deleted, and the arm64 runner can be added as a matrix option
-  #  to the prior job.
-  psibase-contributor-arm64:
-    name: psibase-contributor-arm64
-    strategy:
-      matrix:
-        include:
-          - runner: arm-runner-2
-            platform: "linux/arm64"
-            platform_short: "arm64"
-    runs-on: ${{ matrix.runner }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          submodules: false
-          fetch-depth: 0
 
-      - name: Building ${{ matrix.platform_short }}
-        run: true
-
-      - name: Config docker buildx
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login in to registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set BASE_IMAGE
-        id: base_img
-        env:
-          NEW_BASE: ${{ inputs.new_base }}
-          IS_PR: ${{ github.event_name == 'pull_request' }}
-        run: |
-          if [[ "$NEW_BASE" == "true" && "$IS_PR" == "true" ]]; then
-            echo "Skipping PR build on arm64"
-          elif [[ "$NEW_BASE" == "true" ]]; then
-            echo "BASE_IMAGE=ghcr.io/gofractally/psibase-builder-ubuntu-2204:${{ github.sha }}" >> $GITHUB_OUTPUT
-          else
-            latest_tag=$(./.github/scripts/latest-tag.sh "gofractally/psibase-builder-ubuntu-2204")
-            echo "BASE_IMAGE=ghcr.io/gofractally/psibase-builder-ubuntu-2204:${latest_tag}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Set TOOL_CONFIG_IMAGE
-        id: tool_cfg_img
-        env:
-          NEW_TOOLS: ${{ inputs.new_tools }}
-          IS_PR: ${{ github.event_name == 'pull_request' }}
-        run: |
-          if [[ "$NEW_TOOLS" == "true" && "$IS_PR" == "true" ]]; then
-            echo "Skipping PR build on arm64"
-          elif [[ "$NEW_TOOLS" == "true" ]]; then
-            echo "TOOL_CONFIG_IMAGE=ghcr.io/gofractally/https-tool-config:${{ github.sha }}" >> $GITHUB_OUTPUT
-          else
-            latest_tag=$(./.github/scripts/latest-tag.sh "gofractally/https-tool-config")
-            echo "TOOL_CONFIG_IMAGE=ghcr.io/gofractally/https-tool-config:${latest_tag}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Build & publish
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          file: docker/psibase-contributor.Dockerfile
-          build-args: |
-            BASE_IMAGE=${{ steps.base_img.outputs.BASE_IMAGE }}
-            TOOL_CONFIG_IMAGE=${{ steps.tool_cfg_img.outputs.TOOL_CONFIG_IMAGE }}
-          tags: "ghcr.io/${{ github.repository_owner }}/psibase-contributor:${{ github.sha }}-${{ matrix.platform_short }}"
-          platforms: ${{ matrix.platform }}
-          provenance: false
-          outputs: type=image
   merge: 
     name: merge multi-platform images
     if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
-    needs: [psibase-contributor, psibase-contributor-arm64]
+    needs: [psibase-contributor]
     steps:
       - name: Config docker buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/tool-config.yml
+++ b/.github/workflows/tool-config.yml
@@ -12,12 +12,12 @@ jobs:
     strategy:
       matrix:
         protocol: ["http", "https"]
-        runner: [ubuntu-latest, arm-runner-1]
+        runner: [ubuntu-latest, arm-runner-2]
         include:
         - runner: ubuntu-latest
           platform: "linux/amd64"
           platform_short: "amd64"
-        - runner: arm-runner-1
+        - runner: arm-runner-2
           platform: "linux/arm64"
           platform_short: "arm64"
     runs-on: ${{ matrix.runner }}
@@ -37,31 +37,6 @@ jobs:
 
       - name: Building ${{ matrix.platform_short }}
         run: true
-
-      # Docker install step can be removed after arm runners are out of beta
-      - name: Install docker
-        if: matrix.runner == 'arm-runner-1'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -yq ca-certificates curl
-          sudo install -m 0755 -d /etc/apt/keyrings
-          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-          sudo chmod a+r /etc/apt/keyrings/docker.asc
-          
-          # Add the repository to Apt sources:
-          echo \
-            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update
-
-          # Install
-          sudo apt-get install -yq docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-
-          # Give current user permission to run docker without sudo
-          sudo usermod -aG docker $USER
-          sudo apt-get install -yq acl
-          sudo setfacl --modify user:$USER:rw /var/run/docker.sock
 
       - name: Config docker buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
The new arm runner has docker preinstalled on it. 
I believe this is the arm runner that will be used as github's arm-runners project enters the public beta.

Updates on the public beta:
https://github.com/github/roadmap/issues/970
