### PR TITLE
add rust programs to path

### DIFF
--- a/docker/psibase-contributor.Dockerfile
+++ b/docker/psibase-contributor.Dockerfile
@@ -85,6 +85,9 @@ RUN mkdir -p ${PSINODE_PATH}    \
     && git clone https://github.com/gofractally/psibase.git . \
     && git submodule update --init --recursive
 
+# Add locally built rust programs to path
+ENV PATH=${PSINODE_PATH}/build/rust/release:$PATH
+
 # Copy in tool config
 COPY --from=toolconfig / /
 


### PR DESCRIPTION
Primarily so we can more easily use locally built `cargo-psibase` in psibase contributor