### PR TITLE
Fix build

### DIFF
--- a/docker/ubuntu-2204-builder.Dockerfile
+++ b/docker/ubuntu-2204-builder.Dockerfile
@@ -88,7 +88,7 @@ RUN cd /root \
     wasm32-wasip1           \
     # Cargo tools
     && /opt/cargo/bin/cargo install \
-    cargo-component@0.15.0  \
+    cargo-component@0.21.1  \
     mdbook                  \
     mdbook-linkcheck        \
     mdbook-mermaid          \

--- a/docker/ubuntu-2404-builder.Dockerfile
+++ b/docker/ubuntu-2404-builder.Dockerfile
@@ -82,7 +82,7 @@ RUN cd /root \
     wasm32-wasip1           \
     # Cargo tools
     && /opt/cargo/bin/cargo install \
-    cargo-component@0.15.0  \
+    cargo-component@0.21.1  \
     mdbook                  \
     mdbook-linkcheck        \
     mdbook-mermaid          \


### PR DESCRIPTION
The latest version of parse_arg uses unstable features.  Update cargo-component to 0.21.1, which pins the dependency to a version that works.