### PR TITLE
Upgrading yarn and locking cargo-component to v0.20.0

### DIFF
--- a/docker/ubuntu-2204-builder.Dockerfile
+++ b/docker/ubuntu-2204-builder.Dockerfile
@@ -72,7 +72,8 @@ RUN <<EOT bash
     rm \$NODEPATH.tar.xz
     mv \$NODEPATH node-v20.11.0
     export PATH="/opt/node-v20.11.0/bin:$PATH"
-    npm i -g yarn
+    corepack enable
+    yarn set version stable
 EOT
 ENV PATH=/opt/node-v20.11.0/bin:$PATH
 

--- a/docker/ubuntu-2204-builder.Dockerfile
+++ b/docker/ubuntu-2204-builder.Dockerfile
@@ -89,7 +89,7 @@ RUN cd /root \
     wasm32-wasip1           \
     # Cargo tools
     && /opt/cargo/bin/cargo install \
-    cargo-component@0.21.1  \
+    cargo-component@0.20.0 --locked  \
     mdbook                  \
     mdbook-linkcheck        \
     mdbook-mermaid          \

--- a/docker/ubuntu-2204-builder.Dockerfile
+++ b/docker/ubuntu-2204-builder.Dockerfile
@@ -73,7 +73,7 @@ RUN <<EOT bash
     mv \$NODEPATH node-v20.11.0
     export PATH="/opt/node-v20.11.0/bin:$PATH"
     corepack enable
-    yarn set version stable
+    corepack install -g yarn@stable
 EOT
 ENV PATH=/opt/node-v20.11.0/bin:$PATH
 

--- a/docker/ubuntu-2404-builder.Dockerfile
+++ b/docker/ubuntu-2404-builder.Dockerfile
@@ -66,7 +66,8 @@ RUN <<EOT bash
     rm \$NODEPATH.tar.xz
     mv \$NODEPATH node-v20.11.0
     export PATH="/opt/node-v20.11.0/bin:$PATH"
-    npm i -g yarn
+    corepack enable
+    yarn set version stable
 EOT
 ENV PATH=/opt/node-v20.11.0/bin:$PATH
 

--- a/docker/ubuntu-2404-builder.Dockerfile
+++ b/docker/ubuntu-2404-builder.Dockerfile
@@ -83,7 +83,7 @@ RUN cd /root \
     wasm32-wasip1           \
     # Cargo tools
     && /opt/cargo/bin/cargo install \
-    cargo-component@0.21.1  \
+    cargo-component@0.20.0 --locked  \
     mdbook                  \
     mdbook-linkcheck        \
     mdbook-mermaid          \

--- a/docker/ubuntu-2404-builder.Dockerfile
+++ b/docker/ubuntu-2404-builder.Dockerfile
@@ -67,7 +67,7 @@ RUN <<EOT bash
     mv \$NODEPATH node-v20.11.0
     export PATH="/opt/node-v20.11.0/bin:$PATH"
     corepack enable
-    yarn set version stable
+    corepack install -g yarn@stable
 EOT
 ENV PATH=/opt/node-v20.11.0/bin:$PATH
 


### PR DESCRIPTION
- yarn upgrade to 4.x.x is needed for consolidating builds and ejecting web builds from CMake.
- cargo-component v0.20.0 saves us (on Apple Silicon) from the shim problem introduced in cargo-component v0.21.0